### PR TITLE
Noiuc1

### DIFF
--- a/jbrowse2/blastxml_to_gapped_gff3.py
+++ b/jbrowse2/blastxml_to_gapped_gff3.py
@@ -16,7 +16,9 @@ blast hits. This tool aims to fill that "gap".
 """
 
 
-def blastxml2gff3(blastxml, min_gap=3, trim=False, trim_end=False, include_seq=False):
+def blastxml2gff3(
+    blastxml, min_gap=3, trim=False, trim_end=False, include_seq=False
+):
     from Bio.Blast import NCBIXML
     from Bio.Seq import Seq
     from Bio.SeqRecord import SeqRecord
@@ -32,7 +34,7 @@ def blastxml2gff3(blastxml, min_gap=3, trim=False, trim_end=False, include_seq=F
 
         recid = record.query
         if " " in recid:
-            recid = recid[0: recid.index(" ")]
+            recid = recid[0 : recid.index(" ")]
 
         rec = SeqRecord(Seq("ACTG"), id=recid)
         for idx_hit, hit in enumerate(record.alignments):
@@ -72,7 +74,7 @@ def blastxml2gff3(blastxml, min_gap=3, trim=False, trim_end=False, include_seq=F
                     qualifiers["blast_" + prop] = getattr(hsp, prop, None)
 
                 desc = hit.title.split(" >")[0]
-                qualifiers["description"] = desc[desc.index(" "):]
+                qualifiers["description"] = desc[desc.index(" ") :]
 
                 # This required a fair bit of sketching out/match to figure out
                 # the first time.
@@ -84,7 +86,9 @@ def blastxml2gff3(blastxml, min_gap=3, trim=False, trim_end=False, include_seq=F
                 # may be longer than the parent feature, so we use the supplied
                 # subject/hit length to calculate the real ending of the target
                 # protein.
-                parent_match_end = hsp.query_start + hit.length + hsp.query.count("-")
+                parent_match_end = (
+                    hsp.query_start + hit.length + hsp.query.count("-")
+                )
 
                 # If we trim the left end, we need to trim without losing information.
                 used_parent_match_start = parent_match_start
@@ -98,7 +102,9 @@ def blastxml2gff3(blastxml, min_gap=3, trim=False, trim_end=False, include_seq=F
 
                 # The ``match`` feature will hold one or more ``match_part``s
                 top_feature = SeqFeature(
-                    SimpleLocation(used_parent_match_start, parent_match_end, strand=0),
+                    SimpleLocation(
+                        used_parent_match_start, parent_match_end, strand=0
+                    ),
                     type=match_type,
                     qualifiers=qualifiers,
                 )
@@ -114,10 +120,14 @@ def blastxml2gff3(blastxml, min_gap=3, trim=False, trim_end=False, include_seq=F
                     )
                 ):
                     part_qualifiers["Gap"] = cigar
-                    part_qualifiers["ID"] = qualifiers["ID"] + (".%s" % idx_part)
+                    part_qualifiers["ID"] = qualifiers["ID"] + (
+                        ".%s" % idx_part
+                    )
 
                     # Otherwise, we have to account for the subject start's location
-                    match_part_start = parent_match_start + hsp.sbjct_start + start - 1
+                    match_part_start = (
+                        parent_match_start + hsp.sbjct_start + start - 1
+                    )
 
                     # We used to use hsp.align_length here, but that includes
                     # gaps in the parent sequence
@@ -128,7 +138,9 @@ def blastxml2gff3(blastxml, min_gap=3, trim=False, trim_end=False, include_seq=F
 
                     top_feature.sub_features.append(
                         SeqFeature(
-                            SimpleLocation(match_part_start, match_part_end, strand=1),
+                            SimpleLocation(
+                                match_part_start, match_part_end, strand=1
+                            ),
                             type="match_part",
                             qualifiers=copy.deepcopy(part_qualifiers),
                         )
@@ -161,9 +173,9 @@ def __remove_query_gaps(query, match, subject):
     fm = ""
     fs = ""
     for position in re.finditer("-", query):
-        fq += query[prev: position.start()]
-        fm += match[prev: position.start()]
-        fs += subject[prev: position.start()]
+        fq += query[prev : position.start()]
+        fm += match[prev : position.start()]
+        fs += subject[prev : position.start()]
         prev = position.start() + 1
     fq += query[prev:]
     fm += match[prev:]
@@ -202,7 +214,11 @@ def generate_parts(query, match, subject, ignore_under=3):
         region_m.append(m)
         region_s.append(s)
 
-        if mismatch_count >= ignore_under and region_start != -1 and region_end != -1:
+        if (
+            mismatch_count >= ignore_under
+            and region_start != -1
+            and region_end != -1
+        ):
             region_q = region_q[0:-ignore_under]
             region_m = region_m[0:-ignore_under]
             region_s = region_s[0:-ignore_under]
@@ -238,7 +254,9 @@ def _qms_to_matches(query, match, subject, strict_m=True):
             else:
                 ret = "X"
         else:
-            log.warn("Bad data: \n\t%s\n\t%s\n\t%s\n" % (query, match, subject))
+            log.warn(
+                "Bad data: \n\t%s\n\t%s\n\t%s\n" % (query, match, subject)
+            )
 
         if strict_m:
             if ret == "=" or ret == "X":
@@ -290,9 +308,13 @@ if __name__ == "__main__":
         help="Trim blast hits to be only as long as the parent feature",
     )
     parser.add_argument(
-        "--trim_end", action="store_true", help="Cut blast results off at end of gene"
+        "--trim_end",
+        action="store_true",
+        help="Cut blast results off at end of gene",
     )
-    parser.add_argument("--include_seq", action="store_true", help="Include sequence")
+    parser.add_argument(
+        "--include_seq", action="store_true", help="Include sequence"
+    )
     args = parser.parse_args()
 
     for rec in blastxml2gff3(**vars(args)):

--- a/jbrowse2/blastxml_to_gapped_gff3.py
+++ b/jbrowse2/blastxml_to_gapped_gff3.py
@@ -16,9 +16,7 @@ blast hits. This tool aims to fill that "gap".
 """
 
 
-def blastxml2gff3(
-    blastxml, min_gap=3, trim=False, trim_end=False, include_seq=False
-):
+def blastxml2gff3(blastxml, min_gap=3, trim=False, trim_end=False, include_seq=False):
     from Bio.Blast import NCBIXML
     from Bio.Seq import Seq
     from Bio.SeqRecord import SeqRecord
@@ -86,9 +84,7 @@ def blastxml2gff3(
                 # may be longer than the parent feature, so we use the supplied
                 # subject/hit length to calculate the real ending of the target
                 # protein.
-                parent_match_end = (
-                    hsp.query_start + hit.length + hsp.query.count("-")
-                )
+                parent_match_end = hsp.query_start + hit.length + hsp.query.count("-")
 
                 # If we trim the left end, we need to trim without losing information.
                 used_parent_match_start = parent_match_start
@@ -102,9 +98,7 @@ def blastxml2gff3(
 
                 # The ``match`` feature will hold one or more ``match_part``s
                 top_feature = SeqFeature(
-                    SimpleLocation(
-                        used_parent_match_start, parent_match_end, strand=0
-                    ),
+                    SimpleLocation(used_parent_match_start, parent_match_end, strand=0),
                     type=match_type,
                     qualifiers=qualifiers,
                 )
@@ -120,14 +114,10 @@ def blastxml2gff3(
                     )
                 ):
                     part_qualifiers["Gap"] = cigar
-                    part_qualifiers["ID"] = qualifiers["ID"] + (
-                        ".%s" % idx_part
-                    )
+                    part_qualifiers["ID"] = qualifiers["ID"] + (".%s" % idx_part)
 
                     # Otherwise, we have to account for the subject start's location
-                    match_part_start = (
-                        parent_match_start + hsp.sbjct_start + start - 1
-                    )
+                    match_part_start = parent_match_start + hsp.sbjct_start + start - 1
 
                     # We used to use hsp.align_length here, but that includes
                     # gaps in the parent sequence
@@ -138,9 +128,7 @@ def blastxml2gff3(
 
                     top_feature.sub_features.append(
                         SeqFeature(
-                            SimpleLocation(
-                                match_part_start, match_part_end, strand=1
-                            ),
+                            SimpleLocation(match_part_start, match_part_end, strand=1),
                             type="match_part",
                             qualifiers=copy.deepcopy(part_qualifiers),
                         )
@@ -214,11 +202,7 @@ def generate_parts(query, match, subject, ignore_under=3):
         region_m.append(m)
         region_s.append(s)
 
-        if (
-            mismatch_count >= ignore_under
-            and region_start != -1
-            and region_end != -1
-        ):
+        if mismatch_count >= ignore_under and region_start != -1 and region_end != -1:
             region_q = region_q[0:-ignore_under]
             region_m = region_m[0:-ignore_under]
             region_s = region_s[0:-ignore_under]
@@ -254,9 +238,7 @@ def _qms_to_matches(query, match, subject, strict_m=True):
             else:
                 ret = "X"
         else:
-            log.warn(
-                "Bad data: \n\t%s\n\t%s\n\t%s\n" % (query, match, subject)
-            )
+            log.warn("Bad data: \n\t%s\n\t%s\n\t%s\n" % (query, match, subject))
 
         if strict_m:
             if ret == "=" or ret == "X":
@@ -312,9 +294,7 @@ if __name__ == "__main__":
         action="store_true",
         help="Cut blast results off at end of gene",
     )
-    parser.add_argument(
-        "--include_seq", action="store_true", help="Include sequence"
-    )
+    parser.add_argument("--include_seq", action="store_true", help="Include sequence")
     args = parser.parse_args()
 
     for rec in blastxml2gff3(**vars(args)):

--- a/jbrowse2/gff3_rebase.py
+++ b/jbrowse2/gff3_rebase.py
@@ -65,7 +65,10 @@ def feature_lambda(feature_list, test, test_kwargs, subfeatures=True):
 
         if hasattr(feature, "sub_features"):
             for x in feature_lambda(
-                feature.sub_features, test, test_kwargs, subfeatures=subfeatures
+                feature.sub_features,
+                test,
+                test_kwargs,
+                subfeatures=subfeatures,
             ):
                 yield x
 
@@ -197,7 +200,9 @@ if __name__ == "__main__":
         help="Child GFF3 annotations to rebase against parent",
     )
     parser.add_argument(
-        "--interpro", action="store_true", help="Interpro specific modifications"
+        "--interpro",
+        action="store_true",
+        help="Interpro specific modifications",
     )
     parser.add_argument(
         "--protein2dna",

--- a/jbrowse2/jb2_webserver.py
+++ b/jbrowse2/jb2_webserver.py
@@ -44,7 +44,9 @@ from http.server import SimpleHTTPRequestHandler
 DEFAULT_PORT = 8080
 
 
-def copy_byte_range(infile, outfile, start=None, stop=None, bufsize=16 * 1024):
+def copy_byte_range(
+    infile, outfile, start=None, stop=None, bufsize=16 * 1024
+):
     """Like shutil.copyfileobj, but only copy a range of the streams.
 
     Both start and stop are inclusive.
@@ -129,7 +131,9 @@ class RangeRequestHandler(SimpleHTTPRequestHandler):
             last = file_len - 1
         response_length = last - first + 1
 
-        self.send_header("Content-Range", "bytes %s-%s/%s" % (first, last, file_len))
+        self.send_header(
+            "Content-Range", "bytes %s-%s/%s" % (first, last, file_len)
+        )
         self.send_header("Content-Length", str(response_length))
         self.send_header("Last-Modified", self.date_time_string(fs.st_mtime))
         self.end_headers()
@@ -169,7 +173,9 @@ if __name__ == "__main__":
         help=f"Port to listen on (default: {DEFAULT_PORT})",
     )
     parser.add_argument(
-        "--bind", default="0.0.0.0", help="IP address to bind to (default: 0.0.0.0)"
+        "--bind",
+        default="0.0.0.0",
+        help="IP address to bind to (default: 0.0.0.0)",
     )
     args = parser.parse_args()
 

--- a/jbrowse2/jb2_webserver.py
+++ b/jbrowse2/jb2_webserver.py
@@ -44,9 +44,7 @@ from http.server import SimpleHTTPRequestHandler
 DEFAULT_PORT = 8080
 
 
-def copy_byte_range(
-    infile, outfile, start=None, stop=None, bufsize=16 * 1024
-):
+def copy_byte_range(infile, outfile, start=None, stop=None, bufsize=16 * 1024):
     """Like shutil.copyfileobj, but only copy a range of the streams.
 
     Both start and stop are inclusive.
@@ -131,9 +129,7 @@ class RangeRequestHandler(SimpleHTTPRequestHandler):
             last = file_len - 1
         response_length = last - first + 1
 
-        self.send_header(
-            "Content-Range", "bytes %s-%s/%s" % (first, last, file_len)
-        )
+        self.send_header("Content-Range", "bytes %s-%s/%s" % (first, last, file_len))
         self.send_header("Content-Length", str(response_length))
         self.send_header("Last-Modified", self.date_time_string(fs.st_mtime))
         self.end_headers()

--- a/jbrowse2/jbrowse2.py
+++ b/jbrowse2/jbrowse2.py
@@ -232,9 +232,7 @@ class ColorScaling(object):
         elif "scaling" in track:
             if track["scaling"]["method"] == "ignore":
                 if track["scaling"]["scheme"]["color"] != "__auto__":
-                    trackConfig["style"]["color"] = track["scaling"][
-                        "scheme"
-                    ]["color"]
+                    trackConfig["style"]["color"] = track["scaling"]["scheme"]["color"]
                 else:
                     trackConfig["style"]["color"] = self.hex_from_rgb(
                         *self._get_colours()
@@ -261,18 +259,13 @@ class ColorScaling(object):
                             "blue": blue,
                         }
                     )
-                    trackConfig["style"]["color"] = color_function.replace(
-                        "\n", ""
-                    )
+                    trackConfig["style"]["color"] = color_function.replace("\n", "")
                 elif trackFormat == "gene_calls":
                     # Default values, based on GFF3 spec
                     min_val = 0
                     max_val = 1000
                     # Get min/max and build a scoring function since JBrowse doesn't
-                    if (
-                        scales["type"] == "automatic"
-                        or scales["type"] == "__auto__"
-                    ):
+                    if scales["type"] == "automatic" or scales["type"] == "__auto__":
                         min_val, max_val = self.min_max_gff(gff3)
                     else:
                         min_val = scales.get("min", 0)
@@ -280,9 +273,7 @@ class ColorScaling(object):
 
                     if scheme["color"] == "__auto__":
                         user_color = "undefined"
-                        auto_color = "'%s'" % self.hex_from_rgb(
-                            *self._get_colours()
-                        )
+                        auto_color = "'%s'" % self.hex_from_rgb(*self._get_colours())
                     elif scheme["color"].startswith("#"):
                         user_color = "'%s'" % self.hex_from_rgb(
                             *self.rgb_from_hex(scheme["color"][1:])
@@ -290,9 +281,7 @@ class ColorScaling(object):
                         auto_color = "undefined"
                     else:
                         user_color = "undefined"
-                        auto_color = "'%s'" % self.hex_from_rgb(
-                            *self._get_colours()
-                        )
+                        auto_color = "'%s'" % self.hex_from_rgb(*self._get_colours())
 
                     color_function = self.COLOR_FUNCTION_TEMPLATE_QUAL.format(
                         **{
@@ -304,9 +293,7 @@ class ColorScaling(object):
                         }
                     )
 
-                    trackConfig["style"]["color"] = color_function.replace(
-                        "\n", ""
-                    )
+                    trackConfig["style"]["color"] = color_function.replace("\n", "")
         return trackConfig
 
 
@@ -402,9 +389,7 @@ class JbrowseConnector(object):
 
     def subprocess_check_call(self, command, output=None):
         if output:
-            log.debug(
-                "cd %s && %s >  %s", self.outdir, " ".join(command), output
-            )
+            log.debug("cd %s && %s >  %s", self.outdir, " ".join(command), output)
             subprocess.check_call(command, cwd=self.outdir, stdout=output)
         else:
             log.debug("cd %s && %s", self.outdir, " ".join(command))
@@ -474,7 +459,7 @@ class JbrowseConnector(object):
                     genome_name  # first one for all tracks - other than paf
                 )
                 self.genome_firstcontig = None
-                fl = open(fapath, 'r').readline().strip().split('>', 1)
+                fl = open(fapath, "r").readline().strip().split(">", 1)
                 if len(fl) > 1:
                     self.genome_firstcontig = fl[1].strip()
         if self.config_json.get("assemblies", None):
@@ -638,9 +623,7 @@ class JbrowseConnector(object):
         self.subprocess_check_call(cmd)
         # Construct samples list
         # We could get this from galaxy metadata, not sure how easily.
-        ps = subprocess.Popen(
-            ["grep", "^s [^ ]*", "-o", data], stdout=subprocess.PIPE
-        )
+        ps = subprocess.Popen(["grep", "^s [^ ]*", "-o", data], stdout=subprocess.PIPE)
         output = subprocess.check_output(("sort", "-u"), stdin=ps.stdout)
         ps.wait()
         outp = output.decode("ascii")
@@ -800,9 +783,7 @@ class JbrowseConnector(object):
         url = fname
         self.subprocess_check_call(["cp", data, dest])
         bloc = {"uri": url}
-        if bam_index is not None and os.path.exists(
-            os.path.realpath(bam_index)
-        ):
+        if bam_index is not None and os.path.exists(os.path.realpath(bam_index)):
             # bai most probably made by galaxy and stored in galaxy dirs, need to copy it to dest
             self.subprocess_check_call(
                 ["cp", os.path.realpath(bam_index), dest + ".bai"]
@@ -813,13 +794,9 @@ class JbrowseConnector(object):
             #      => no index generated by galaxy, but there might be one next to the symlink target
             #      this trick allows to skip the bam sorting made by galaxy if already done outside
             if os.path.exists(os.path.realpath(data) + ".bai"):
-                self.symlink_or_copy(
-                    os.path.realpath(data) + ".bai", dest + ".bai"
-                )
+                self.symlink_or_copy(os.path.realpath(data) + ".bai", dest + ".bai")
             else:
-                log.warn(
-                    "Could not find a bam index (.bai file) for %s", data
-                )
+                log.warn("Could not find a bam index (.bai file) for %s", data)
         trackDict = {
             "type": "AlignmentsTrack",
             "trackId": tId,
@@ -902,9 +879,7 @@ class JbrowseConnector(object):
                 dest,
             )  # "gff3sort.pl --precise '%s' | grep -v \"^$\" > '%s'"
             self.subprocess_popen(cmd)
-            self.subprocess_check_call(
-                ["tabix", "-f", "-p", "gff", dest + ".gz"]
-            )
+            self.subprocess_check_call(["tabix", "-f", "-p", "gff", dest + ".gz"])
 
     def _sort_bed(self, data, dest):
         # Only index if not already done
@@ -1069,9 +1044,7 @@ class JbrowseConnector(object):
         }
 
         if query_refnames:
-            json_track_data["adapter"][
-                "refNamesQueryTemplate"
-            ]: query_refnames
+            json_track_data["adapter"]["refNamesQueryTemplate"]: query_refnames
 
         self.subprocess_check_call(
             [
@@ -1133,9 +1106,7 @@ class JbrowseConnector(object):
                 rest_url,
             ]
             hashData = "|".join(hashData).encode("utf-8")
-            outputTrackConfig["label"] = (
-                hashlib.md5(hashData).hexdigest() + "_%s" % i
-            )
+            outputTrackConfig["label"] = hashlib.md5(hashData).hexdigest() + "_%s" % i
             outputTrackConfig["metadata"] = extra_metadata
             outputTrackConfig["name"] = track_human_label
 
@@ -1167,9 +1138,9 @@ class JbrowseConnector(object):
                     outputTrackConfig,
                 )
             elif dataset_ext == "bam":
-                real_indexes = track["conf"]["options"]["pileup"][
-                    "bam_indices"
-                ]["bam_index"]
+                real_indexes = track["conf"]["options"]["pileup"]["bam_indices"][
+                    "bam_index"
+                ]
                 if not isinstance(real_indexes, list):
                     # <bam_indices>
                     #  <bam_index>/path/to/a.bam.bai</bam_index>
@@ -1243,42 +1214,42 @@ class JbrowseConnector(object):
         view_json = {"type": "LinearGenomeView", "tracks": tracks_data}
 
         refName = None
+        drdict = {
+            "reversed": False,
+            "assemblyName": self.genome_name,
+            "start": 0,
+            "end": 100000,
+        }
+
         if data.get("defaultLocation", ""):
             ddl = data["defaultLocation"]
-            loc_match = re.search(r"^([^:]+):(\d+)\.+(\d+)$", ddl)
+            loc_match = re.search(r"^([^:]+):(\d*)\.*(\d*)$", ddl)
             if loc_match:
                 refName = loc_match.group(1)
-                start = int(loc_match.group(2))
-                end = int(loc_match.group(3))
+                drdict["refName"] = refName
+                if loc_match.group(2) > "":
+                    drdict["start"] = int(loc_match.group(2))
+                if loc_match.group(3) > "":
+                    drdict["end"] = int(loc_match.group(3))
             else:
                 logging.info(
                     "@@@ regexp could not match contig:start..end in the supplied location %s - please fix"
                     % ddl
                 )
         elif self.genome_firstcontig is not None:
-            start = 0
-            end = 100000  # Booh, hard coded! waiting for https://github.com/GMOD/jbrowse-components/issues/2708
-            refName = self.genome_firstcontig
+            drdict["refName"] = self.genome_firstcontig
             logging.info(
-                "@@@ no defaultlocation found for default session - using %s as first contig found" % self.genome_firstcontig
+                "@@@ no defaultlocation found for default session - using %s as first contig found"
+                % self.genome_firstcontig
             )
 
-        if refName is not None:
+        if drdict.get("refName", None):
             # TODO displayedRegions is not just zooming to the region, it hides the rest of the chromosome
             view_json["displayedRegions"] = [
-                {
-                    "refName": refName,
-                    "start": start,
-                    "end": end,
-                    "reversed": False,
-                    "assemblyName": self.genome_name,
-                }
+                drdict,
             ]
 
-            logging.info(
-                "@@@ defaultlocation %s for default session"
-                % view_json["displayedRegions"]
-            )
+            logging.info("@@@ defaultlocation %s for default session" % drdict)
         else:
             logging.info(
                 "@@@ no contig name found for default session - please add one!"
@@ -1319,18 +1290,14 @@ class JbrowseConnector(object):
             config_json.update(self.config_json)
         config_data = {}
 
-        config_data["disableAnalytics"] = (
-            data.get("analytics", "false") == "true"
-        )
+        config_data["disableAnalytics"] = data.get("analytics", "false") == "true"
 
         config_data["theme"] = {
             "palette": {
                 "primary": {"main": data.get("primary_color", "#0D233F")},
                 "secondary": {"main": data.get("secondary_color", "#721E63")},
                 "tertiary": {"main": data.get("tertiary_color", "#135560")},
-                "quaternary": {
-                    "main": data.get("quaternary_color", "#FFB11D")
-                },
+                "quaternary": {"main": data.get("quaternary_color", "#FFB11D")},
             },
             "typography": {"fontSize": int(data.get("font_size", 10))},
         }
@@ -1384,9 +1351,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="", epilog="")
     parser.add_argument("--xml", help="Track Configuration")
     parser.add_argument("--outdir", help="Output directory", default="out")
-    parser.add_argument(
-        "--version", "-V", action="version", version="%(prog)s 2.0.1"
-    )
+    parser.add_argument("--version", "-V", action="version", version="%(prog)s 2.0.1")
     args = parser.parse_args()
 
     tree = ET.parse(args.xml)
@@ -1483,8 +1448,7 @@ if __name__ == "__main__":
         track_conf["format"] = track.attrib["format"]
         if track.find("options/style"):
             track_conf["style"] = {
-                item.tag: parse_style_conf(item)
-                for item in track.find("options/style")
+                item.tag: parse_style_conf(item) for item in track.find("options/style")
             }
         if track.find("options/style_labels"):
             track_conf["style_labels"] = {
@@ -1497,9 +1461,7 @@ if __name__ == "__main__":
         track_conf["format"] = track.attrib["format"]
         try:
             # Only pertains to gff3 + blastxml. TODO?
-            track_conf["style"] = {
-                t.tag: t.text for t in track.find("options/style")
-            }
+            track_conf["style"] = {t.tag: t.text for t in track.find("options/style")}
         except TypeError:
             track_conf["style"] = {}
             pass
@@ -1516,9 +1478,9 @@ if __name__ == "__main__":
                         "style"
                     ]  # TODO do we need this anymore?
                 if track_conf.get("style_lables", None):
-                    default_session_data["style_labels"][
-                        key
-                    ] = track_conf.get("style_labels", None)
+                    default_session_data["style_labels"][key] = track_conf.get(
+                        "style_labels", None
+                    )
     default_session_data["defaultLocation"] = root.find(
         "metadata/general/defaultLocation"
     ).text
@@ -1530,9 +1492,7 @@ if __name__ == "__main__":
         "primary_color": root.find("metadata/general/primary_color").text,
         "secondary_color": root.find("metadata/general/secondary_color").text,
         "tertiary_color": root.find("metadata/general/tertiary_color").text,
-        "quaternary_color": root.find(
-            "metadata/general/quaternary_color"
-        ).text,
+        "quaternary_color": root.find("metadata/general/quaternary_color").text,
         "font_size": root.find("metadata/general/font_size").text,
     }
     jc.add_general_configuration(general_data)

--- a/jbrowse2/jbrowse2.xml
+++ b/jbrowse2/jbrowse2.xml
@@ -783,8 +783,10 @@ options need to be supplied and where.
 
 The JBrowse-in-Galaxy tool has been rejected by `a Galaxy IUC
 <https://github.com/galaxyproject/tools-iuc/issues>`__, reviewer.
-It is maintained by who you can help you
-with missing features or bugs in the tool.
+It is maintained by https://github.com/fubar2 who you can help you
+with missing features or bugs in the tool. For the record, he remains unconvinced by the reviewer's logic,
+and disturbed by the distinctly coercive approach to introducing new code,
+compared to the more usual method of providing a working PR.
 
 Options
 -------

--- a/jbrowse2/jbrowse2.xml
+++ b/jbrowse2/jbrowse2.xml
@@ -1,4 +1,4 @@
- <tool id="jbrowse2" name="jbrowse2" version="@TOOL_VERSION@+@WRAPPER_VERSION@_1" profile="22.05">
+ <tool id="jbrowse2" name="jbrowse2" version="@TOOL_VERSION@+@WRAPPER_VERSION@.1" profile="22.05">
     <description>genome browser</description>
     <macros>
         <import>macros.xml</import>
@@ -781,38 +781,36 @@ JBrowse installations straight from Galaxy. It allows you to build up a JBrowse 
 about how to run the command line tools to format your data, and which
 options need to be supplied and where.
 
-The JBrowse-in-Galaxy tool is maintained by `the Galaxy IUC
-<https://github.com/galaxyproject/tools-iuc/issues>`__, who you can help you
+The JBrowse-in-Galaxy tool has been rejected by `a Galaxy IUC
+<https://github.com/galaxyproject/tools-iuc/issues>`__, reviewer.
+It is maintained by who you can help you
 with missing features or bugs in the tool.
 
 Options
 -------
 
-The first option you encounter is the **Reference sequence(s)** to use. This option
-now accepts multiple fasta files, allowing you to build JBrowse2
-instances that contain data for multiple genomes or chrosomomes
-(generally known as "landmark features" in gff3 terminology.)
+**Reference or Assembly**
 
-**Track Groups** represent a set of tracks in a single category. These
-can be used to let your users understand relationships between large
-groups of tracks.
+Choose either a built-in or select one from your history.
+
+Track coordinates and contig names *must* match this reference precisely
+or they will not display.
+
+**Track Groups** represent a set of tracks in a single category.
 
 Annotation Tracks
 -----------------
 
-There are a few different types of tracks supported, each with their own
-set of options:
-
 GFF3/BED
 ~~~~~~~~
 
-These are standard feature tracks. They usually highlight genes,
-mRNAs and other features of interest along a genomic region.
+Standard feature tracks. They usually highlight genes, mRNAs and other features of interest along a genomic region.
 
 When these contain tens of millions of features, such as repeat regions from a VGP assembly, displaying one at a time leads
 to extremely slow loading times when a large region is in view, unless the "LinearPileupDisplay" display option is
 selected for that track in the styling options section. The default is LinearBasicDisplay, which shows all details and works
-well for relatively sparse bed files.
+well for relatively sparse bed files. A better option is to make a bigwig track using a set of windows based on the
+lengths of each assembly or reference contig.
 
 BAM Pileups
 ~~~~~~~~~~~

--- a/jbrowse2/macros.xml
+++ b/jbrowse2/macros.xml
@@ -24,7 +24,7 @@
         </requirements>
     </xml>
     <token name="@DATA_DIR@">\$GALAXY_JBROWSE_SHARED_DIR</token>
-    <token name="@WRAPPER_VERSION@">galaxy0</token>
+    <token name="@WRAPPER_VERSION@">galaxy2</token>
     <token name="@ATTRIBUTION@"><![CDATA[
 **Attribution**
 This Galaxy tool relies on the JBrowse2, maintained by the GMOD Community. The Galaxy wrapper is developed by the IUC


### PR DESCRIPTION
1. Use first reference contig name as a default location if none provided. Fixed range...need to adjust the regexp to allow `contig:` to do the needful
2. Fix track names for all wiggles using a name (like repeat wiggle) propogated through that subworkflow from the name of the input bed feature file. Silly thing to do but works perfectly
3. Adjust version naming for this subversion. Can't change the version if it's immutably tied to the jbrowse2 version hence a fudge.
4. Remove IUC reference from help.
5. fix default region so default is 1..100000 and the first contig name from the reference fasta is the default contig name so there should always be at least something in the default view.