### PR TITLE
Clean up - remove bogus multiple input selection macro setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Currently works for:
  10. vcf
 
 
-![image](https://github.com/fubar2/temporary-tools/assets/6016266/656c0dcd-5800-4350-9a07-8f78d86adc11)
 
 Rejected by IUC so on EU via [temporary tools](https://github.com/usegalaxy-eu/temporary-tools) until the IUC finishes an older one by fixing all the bugs I fixed independently before I found that one. 
 Then we can all use that one!

--- a/jbrowse2/jbrowse2.xml
+++ b/jbrowse2/jbrowse2.xml
@@ -234,11 +234,11 @@ cp '$output.files_path/index.html' '$output'
                         <option value="pileup">BAM Pileup track</option>
                         <option value="wiggle">BigWig track</option>
                         <option value="blast">Blast XML track - converted to GFF</option>
-                        <option value="cool">cool/mcool/scool data in hdf5 data</option>
+                        <option value="cool">HiC as cool/mcool/scool format files</option>
                         <option value="cram">CRAM</option>
                         <option value="gene_calls" selected="true">GFF/GFF3/BED feature track</option>
-                        <option value="hic">HiC (compressed binary) track. Existing cool format must be converted to binary hic - hic_matrix will NOT work.</option>
-                        <option value="maf">Multiple alignment format track. Reference name must match the MAF name exactly to work correctly</option>
+                        <option value="hic">HiC as juicebox_hic format file. Tabular hic_matrix will NOT work.</option>
+                        <option value="maf">Multiple alignment format. Reference name must match the MAF name exactly to work correctly</option>
                         <option value="paf">PAF - approximate mapping positions between two set of sequences</option>
                         <option value="sparql">SPARQL</option>
                        <option value="vcf">VCF SNP annotation</option>

--- a/jbrowse2/jbrowse2.xml
+++ b/jbrowse2/jbrowse2.xml
@@ -93,7 +93,7 @@ cp '$output.files_path/index.html' '$output'
         <track cat="${tg.category}" format="${track.data_format.data_format_select}" visibility="${track.data_format.track_visibility}">
             #if $track.data_format.data_format_select != "sparql":
             <files>
-              #for $dataset in $track.data_format.annotation:
+              #set dataset = $track.data_format.annotation
               <trackFile path="${dataset}" ext="${dataset.ext}" label="${dataset.element_identifier}">
                 <metadata>
                   <dataset id="${__app__.security.encode_id($dataset.id)}" hid="${dataset.hid}"
@@ -128,7 +128,6 @@ cp '$output.files_path/index.html' '$output'
                       />
                 </metadata>
               </trackFile>
-              #end for
             </files>
             #end if
 
@@ -138,17 +137,13 @@ cp '$output.files_path/index.html' '$output'
             #if str($track.data_format.data_format_select) == "pileup":
                 <pileup>
                     <bam_indices>
-                        #for $dataset in $track.data_format.annotation:
                         <bam_index>${dataset.metadata.bam_index}</bam_index>
-                        #end for
                     </bam_indices>
                 </pileup>
             #else if str($track.data_format.data_format_select) == "cram":
                 <cram>
                     <cram_indices>
-                        #for $dataset in $track.data_format.annotation:
                         <cram_index>${dataset.metadata.cram_index}</cram_index>
-                        #end for
                     </cram_indices>
                 </cram>
             #else if str($track.data_format.data_format_select) == "blast":

--- a/jbrowse2/macros.xml
+++ b/jbrowse2/macros.xml
@@ -504,7 +504,7 @@ until the IUC complete their own.
 
 
     <xml name="input_conditional" token_label="Track Data" token_format="data">
-        <param label="@LABEL@" format="@FORMAT@" name="annotation" type="data" multiple="True"/>
+        <param label="@LABEL@" format="@FORMAT@" name="annotation" type="data" multiple="False"/>
     </xml>
     <xml name="citations">
         <citations>


### PR DESCRIPTION
Finally noticed that the macro for selecting a history file allows multiple=True - that makes no sense AFAIK so removed and subsequent breakage where a list was expected fixed.
Users no longer see multiple selection so can't break things by selecting a bunch of files when only one would be helpful.
