### PR TITLE
repair missing track XML errors:

### DIFF
--- a/jbrowse2/jbrowse2.xml
+++ b/jbrowse2/jbrowse2.xml
@@ -1,4 +1,4 @@
- <tool id="jbrowse2" name="JBrowse2" version="@TOOL_VERSION@+@WRAPPER_VERSION@_12" profile="22.05">
+ <tool id="jbrowse2" name="JBrowse2" version="@TOOL_VERSION@+@WRAPPER_VERSION@_14" profile="22.05">
     <description>genome browser</description>
     <macros>
         <import>macros.xml</import>

--- a/jbrowse2/jbrowse2.xml
+++ b/jbrowse2/jbrowse2.xml
@@ -145,18 +145,23 @@ export JBROWSE2_PATH=\$(dirname \$(which jbrowse))/../opt/jbrowse2  &&
     <tracks>
         #for $tg in $assembly.track_groups:
             #for $track in $tg.data_tracks:
+                #set input_exists = "False"
                 #if $track.data_format.useuri.insource == "uri":
-                    <track cat="${tg.category}" format="${track.data_format.data_format_select}" visibility="${track.data_format.track_visibility}">
-                        <files>
-                             <trackFile path="${track.data_format.useuri.annouri}" ext="${track.data_format.data_format_select}"
-                                label="${track.data_format.useuri.annoname}" useuri="yes">
-                                <metadata>
-                                <dataset id = "${track.data_format.useuri.annouri}" />
-                                </metadata>
-                             </trackFile>
-                        </files>
+                        #if $track.data_format.useuri.annouri:
+                        #set input_exists = "True"
+                        <track cat="${tg.category}" format="${track.data_format.data_format_select}" visibility="${track.data_format.track_visibility}">
+                            <files>
+                                 <trackFile path="${track.data_format.useuri.annouri}" ext="${track.data_format.data_format_select}"
+                                    label="${track.data_format.useuri.annoname}" useuri="yes">
+                                    <metadata>
+                                    <dataset id = "${track.data_format.useuri.annouri}" />
+                                    </metadata>
+                                 </trackFile>
+                            </files>
+                        #end if
                 #else if $track.data_format.useuri.insource == "history":
                     #if $track.data_format.useuri.annotation:
+                        #set input_exists = "True"
                     <track cat="${tg.category}" format="${track.data_format.data_format_select}" visibility="${track.data_format.track_visibility}">
                     <files>
                         #for $dataset in $track.data_format.useuri.annotation:
@@ -196,108 +201,110 @@ export JBROWSE2_PATH=\$(dirname \$(which jbrowse))/../opt/jbrowse2  &&
                                       />
                                 </metadata>
                               </trackFile>
-                       #end for
+                        #end for
                     </files>
                     #end if
-                  #end if
-                  <options>
-                    <style>
-                        #if str($track.data_format.data_format_select) in ["gff", "bed", "maf", "blastxml"]:
-                            <type>${track.data_format.jbstyle.display}</type>
-                            #if str($track.data_format.jbstyle.display) in ["LinearBasicDisplay", "LinearVariantDisplay"]:
-                                <trackShowLabels>${track.data_format.jbstyle.show_labels}</trackShowLabels>
-                                <trackShowDescriptions>${track.data_format.jbstyle.show_descriptions}</trackShowDescriptions>
-                            #end if
-                        #else if str($track.data_format.data_format_select) == "vcf":
-                            <type>${track.data_format.jbstyle.track_style.display}</type>
-                            #if str($track.data_format.jbstyle.track_style.display) in ["LinearBasicDisplay", "LinearVariantDisplay"]:
-                                <trackShowLabels>${track.data_format.jbstyle.track_style.show_labels}</trackShowLabels>
-                                <trackShowDescriptions>${track.data_format.jbstyle.track_style.show_descriptions}</trackShowDescriptions>
-                            #end if
+                #end if
+                #if $input_exists == "True":
+                      <options>
+                        <style>
+                            #if str($track.data_format.data_format_select) in ["gff", "bed", "maf", "blastxml"]:
+                                <type>${track.data_format.jbstyle.display}</type>
+                                #if str($track.data_format.jbstyle.display) in ["LinearBasicDisplay", "LinearVariantDisplay"]:
+                                    <trackShowLabels>${track.data_format.jbstyle.show_labels}</trackShowLabels>
+                                    <trackShowDescriptions>${track.data_format.jbstyle.show_descriptions}</trackShowDescriptions>
+                                #end if
+                            #else if str($track.data_format.data_format_select) == "vcf":
+                                <type>${track.data_format.jbstyle.track_style.display}</type>
+                                #if str($track.data_format.jbstyle.track_style.display) in ["LinearBasicDisplay", "LinearVariantDisplay"]:
+                                    <trackShowLabels>${track.data_format.jbstyle.track_style.show_labels}</trackShowLabels>
+                                    <trackShowDescriptions>${track.data_format.jbstyle.track_style.show_descriptions}</trackShowDescriptions>
+                                #end if
 
-                        #end if
-                        #if str($track.data_format.data_format_select) in ["bam", "cram"]:
-                            <type>LinearAlignmentsDisplay</type>
-                        #end if
-                        #if str($track.data_format.data_format_select) in ["hic", "cool", "mcool", "scool"]:
-                            <type>LinearHicDisplay</type>
-                        #end if
-                    </style>
-                    #if str($track.data_format.data_format_select) == "bam":
-                        <bam>
-                        <bam_index>
-                            #for $dataset in $track.data_format.useuri.annotation:
-                                ${dataset.name},${dataset.metadata.bam_index}
-                            #end for
-                        </bam_index>
-                        </bam>
-                    #else if str($track.data_format.data_format_select) == "cram":
-                        <cram>
-                        <cram_index>
-                            #for $dataset in $track.data_format.useuri.annotation:
-                                ${dataset.name},${dataset.metadata.cram_index}
-                            #end for
-                        </cram_index>
-                        </cram>
-                    #else if str($track.data_format.data_format_select) == "blastxml":
-                        <blast>
-                          #if str($track.data_format.blast_parent) != "":
-                            <parent>${track.data_format.blast_parent}</parent>
-                          #end if
-                            <protein>${track.data_format.is_protein}</protein>
-                            <min_gap>${track.data_format.min_gap}</min_gap>
-                        </blast>
-                    #else if str($track.data_format.data_format_select) == "gff":
-                        <gff>
-                          #if $track.data_format.match_part.match_part_select == "true":
-                            <match>${track.data_format.match_part.name}</match>
-                          #end if
-                        </gff>
-                    #else if str($track.data_format.data_format_select) == "paf":
-                        <paf>
-                            #if $track.data_format.pafuseuri.insource == "history":
-                            <genome>
-                                #for $anno in $track.data_format.pafuseuri.annotation:
-                                    ${anno},
-                                #end for
-                            </genome>
-                            <genome_label>
-                                #for $anno in $track.data_format.pafuseuri.annotation:
-                                        ${anno.name},
-                                #end for
-                            </genome_label>
-                            #else:
-                            <genome>
-                                #for $refgenome in $track.data_format.pafuseuri.refuri:
-                                    $refgenome.annotation,
-                                #end for
-                            </genome>
-                            <genome_label>
-                                #for $refgenome in $track.data_format.pafuseuri.refuri:
-                                    ${refgenome.annoname},
-                                #end for
-                            </genome_label>
                             #end if
-                        </paf>
-                    #else if str($track.data_format.data_format_select) == "hic":
-                        <hic>
-                        </hic>
-                    #else if str($track.data_format.data_format_select) == "cool":
-                        <cool>
-                        </cool>
-                    #else if str($track.data_format.data_format_select) == "bed":
-                        <bed>
-                        </bed>
-                    #else if str($track.data_format.data_format_select) == "sparql":
-                        <label>${track.data_format.label}</label>
-                        <sparql>
-                            <url>${track.data_format.url}</url>
-                            <query>${track.data_format.query}</query>
-                            <query_refnames>${track.data_format.query_refnames}</query_refnames>
-                        </sparql>
-                    #end if
-                    </options>
+                            #if str($track.data_format.data_format_select) in ["bam", "cram"]:
+                                <type>LinearAlignmentsDisplay</type>
+                            #end if
+                            #if str($track.data_format.data_format_select) in ["hic", "cool", "mcool", "scool"]:
+                                <type>LinearHicDisplay</type>
+                            #end if
+                        </style>
+                        #if str($track.data_format.data_format_select) == "bam":
+                            <bam>
+                            <bam_index>
+                                #for $dataset in $track.data_format.useuri.annotation:
+                                    ${dataset.name},${dataset.metadata.bam_index}
+                                #end for
+                            </bam_index>
+                            </bam>
+                        #else if str($track.data_format.data_format_select) == "cram":
+                            <cram>
+                            <cram_index>
+                                #for $dataset in $track.data_format.useuri.annotation:
+                                    ${dataset.name},${dataset.metadata.cram_index}
+                                #end for
+                            </cram_index>
+                            </cram>
+                        #else if str($track.data_format.data_format_select) == "blastxml":
+                            <blast>
+                              #if str($track.data_format.blast_parent) != "":
+                                <parent>${track.data_format.blast_parent}</parent>
+                              #end if
+                                <protein>${track.data_format.is_protein}</protein>
+                                <min_gap>${track.data_format.min_gap}</min_gap>
+                            </blast>
+                        #else if str($track.data_format.data_format_select) == "gff":
+                            <gff>
+                              #if $track.data_format.match_part.match_part_select == "true":
+                                <match>${track.data_format.match_part.name}</match>
+                              #end if
+                            </gff>
+                        #else if str($track.data_format.data_format_select) == "paf":
+                            <paf>
+                                #if $track.data_format.pafuseuri.insource == "history":
+                                <genome>
+                                    #for $anno in $track.data_format.pafuseuri.annotation:
+                                        ${anno},
+                                    #end for
+                                </genome>
+                                <genome_label>
+                                    #for $anno in $track.data_format.pafuseuri.annotation:
+                                            ${anno.name},
+                                    #end for
+                                </genome_label>
+                                #else:
+                                <genome>
+                                    #for $refgenome in $track.data_format.pafuseuri.refuri:
+                                        $refgenome.annotation,
+                                    #end for
+                                </genome>
+                                <genome_label>
+                                    #for $refgenome in $track.data_format.pafuseuri.refuri:
+                                        ${refgenome.annoname},
+                                    #end for
+                                </genome_label>
+                                #end if
+                            </paf>
+                        #else if str($track.data_format.data_format_select) == "hic":
+                            <hic>
+                            </hic>
+                        #else if str($track.data_format.data_format_select) == "cool":
+                            <cool>
+                            </cool>
+                        #else if str($track.data_format.data_format_select) == "bed":
+                            <bed>
+                            </bed>
+                        #else if str($track.data_format.data_format_select) == "sparql":
+                            <label>${track.data_format.label}</label>
+                            <sparql>
+                                <url>${track.data_format.url}</url>
+                                <query>${track.data_format.query}</query>
+                                <query_refnames>${track.data_format.query_refnames}</query_refnames>
+                            </sparql>
+                        #end if
+                        </options>
                   </track>
+                  #end if
             #end for
         #end for
     </tracks>

--- a/jbrowse2/jbrowse2.xml
+++ b/jbrowse2/jbrowse2.xml
@@ -140,7 +140,6 @@ export JBROWSE2_PATH=\$(dirname \$(which jbrowse))/../opt/jbrowse2  &&
                   </genome>
                 #end if
             </genomes>
-
     </metadata>
     <tracks>
         #for $tg in $assembly.track_groups:
@@ -566,6 +565,15 @@ export JBROWSE2_PATH=\$(dirname \$(which jbrowse))/../opt/jbrowse2  &&
                             </conditional>
                         </conditional>
                     </repeat>
+                    <repeat name="data_tracks">
+                        <conditional name="data_format">
+                            <param name="data_format_select" value="bam"/>
+                            <conditional name="useuri">
+                                <param name="insource" value="history"/>
+                                <param name="annotation" value=""/>
+                            </conditional>
+                        </conditional>
+                    </repeat>
                 </repeat>
             </repeat>
             <repeat name="assemblies">
@@ -660,8 +668,8 @@ export JBROWSE2_PATH=\$(dirname \$(which jbrowse))/../opt/jbrowse2  &&
                     <has_archive_member path="merlin-sample.bam_5.bam"/>
                     <has_archive_member path="merlinlastz.maf_6.maf.sorted.bed.gz.tbi"/>
                     <has_archive_member path="merlin.blastxml_7.blastxml.gz"/>
-                    <has_archive_member path="dm3test.cool_8.cool.hic"/>
-                    <has_archive_member path="peach-grape-map.paf_9.paf"/>
+                    <has_archive_member path="dm3test.cool_9.cool.hic"/>
+                    <has_archive_member path="peach-grape-map.paf_10.paf"/>
                     <has_archive_member path="Merlin.fa.gz.fai"/>
                     <has_archive_member path="config.json">
                         <has_json_property_with_text property="name" text="Merlin" />


### PR DESCRIPTION
Good timezone @bgruening. 
Another subtle bug in the loops of the XML that generates XML. 
All JB2 track file inputs are optional so can be empty for WF if not available. 
A null input file has been added to the zip test - passes now.

These changes need to be ported to your IUC PR version - the diffs are mostly white space - the real changes are only a few lines to bypass a bogus block of XML generation when there is no input provided. 
